### PR TITLE
Fix server_name type.

### DIFF
--- a/src/chronos.erl
+++ b/src/chronos.erl
@@ -29,7 +29,7 @@
 
 
 %% Types
--type server_name()   :: atom().
+-type server_name()   :: term().
 %%-type server_ref()    :: server_name() | pid().
 -type timer_name()    :: term().
 -type function_name() :: atom().


### PR DESCRIPTION
atom() as a server name is too restrictive.
