### PR TITLE
remove gen_leader from list of required applications

### DIFF
--- a/ebin/chronos.app
+++ b/ebin/chronos.app
@@ -3,5 +3,5 @@
 	{vsn, "0.1.2"},
 	{modules, ['chronos']},
 	{registered, []},
-	{applications, [kernel,stdlib,gproc,gen_leader]}
+	{applications, [kernel,stdlib,gproc]}
 ]}.


### PR DESCRIPTION
Hello,

In order to fix release generation using rebar2 `gen_leader` should be removed from applications list.

Here below is the error I get using the latest master branch.

```
rebar generate
==> rel (generate)
ERROR: generate failed while processing /home/user/project/rel: {'EXIT',{{badmatch,{error,"Release \"project\" uses non existing application gen_leader"}},
```
